### PR TITLE
fix: stop bundling game DLLs that cause log errors; alphabetize sort the dropdown list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,29 @@
+# Visual Studio
+.vs/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Copilot caches
+**/CopilotIndices/
+**/*.db
+**/*.db-shm
+**/*.db-wal
+
+# Build outputs (any depth)
+**/[Bb]in/
+**/[Oo]bj/
+Debug/
+Release/
+[xX]64/
+[Bb]uild/
+[Bb]uilds/
+
+# Editors (optional; include only if acceptable upstream)
+.vscode/
+.idea/
+
 ﻿/.idea/.idea.AchievementManager/.idea/.gitignore
 /AchievementManager/obj/Release/net472/.NETFramework,Version=v4.7.2.AssemblyAttributes.cs
 /AchievementManager/obj/Release/net48/.NETFramework,Version=v4.8.AssemblyAttributes.cs

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ Release/
 [Bb]uild/
 [Bb]uilds/
 
-# Editors (optional; include only if acceptable upstream)
+# Editors (optional: reduce noise uploads that are not needed)
 .vscode/
 .idea/
 

--- a/AchievementManager/AchievementManager.csproj
+++ b/AchievementManager/AchievementManager.csproj
@@ -15,10 +15,12 @@
 
     <ItemGroup>
         <Reference Include="Colossal.Localization">
-            <HintPath>G:\SteamLibrary\steamapps\common\Cities Skylines II\Cities2_Data\Managed\Colossal.Localization.dll</HintPath>
+            <HintPath>$(ManagedPath)\Colossal.Localization.dll</HintPath>
+			<Private>false</Private>    <!-- don't ship game DLLs -->
         </Reference>
         <Reference Include="Colossal.PSI.Common">
-            <HintPath>G:\SteamLibrary\steamapps\common\Cities Skylines II\Cities2_Data\Managed\Colossal.PSI.Common.dll</HintPath>
+            <HintPath>$(ManagedPath)\Colossal.PSI.Common.dll</HintPath>
+			<Private>false</Private>    <!-- don't ship game DLLs -->
         </Reference>
         <Reference Include="Game">
             <Private>false</Private>

--- a/AchievementManager/AchievementManagerSettings.cs
+++ b/AchievementManager/AchievementManagerSettings.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Colossal;
 using Colossal.IO.AssetDatabase;
 using Colossal.PSI.Common;
+
 using Game.Achievements;
 using Game.Modding;
 using Game.Settings;
 using Game.UI.Widgets;
+
 using UnityEngine;
 
 namespace AchievementManager
@@ -18,7 +21,6 @@ namespace AchievementManager
         private int _achivementmaxprogres = 5;
         private int _achivementminprogres = 0;
         private bool _isprogress = false;
-
         public AchievementManagerSettings(IMod mod) : base(mod)
         {
             SetDefaults();
@@ -95,7 +97,7 @@ namespace AchievementManager
         // [SettingsUIButton]
         // public bool SetAchievementProgress
         // {
-        //     set 
+        //     set
         //     {
         //         if (SelectedAchievement != null && _isprogress)
         //         {
@@ -113,8 +115,8 @@ namespace AchievementManager
         //             // Ensure the progress is within the defined min and max range
         //             if(SelectedAchievement.isIncremental)
         //                 PlatformManager.instance.IndicateAchievementProgress(SelectedAchievement.id,AchievementProgress, IndicateType.Absolute);
-        //             
-        //             
+        //
+        //
         //         }
         //     }
         // }
@@ -126,7 +128,7 @@ namespace AchievementManager
         private void Test()
         {
             foreach (var field in typeof(Achievements).GetFields())
-                
+
                 switch (field.Name)
                 {
                     case "MyFirstCity":
@@ -229,13 +231,18 @@ namespace AchievementManager
 
         public DropdownItem<string>[] GetAchievementDropdownItems()
         {
-            return PlatformManager.instance.EnumerateAchievements()
+            // Sort achievements alphabetically by internalName, user-friendly list.
+            // (case-insensitive ordering so "alpha" and "Alpha" group together)
+            var items = PlatformManager.instance?.EnumerateAchievements()?
+                .OrderBy(a => a.internalName, StringComparer.OrdinalIgnoreCase)
                 .Select(a => new DropdownItem<string>
                 {
                     value = a.internalName,
                     displayName = a.internalName // or use localization if needed
                 })
                 .ToArray();
+
+            return items ?? Array.Empty<DropdownItem<string>>();    // null-safe path
         }
     }
 
@@ -253,7 +260,7 @@ namespace AchievementManager
         {
             return new Dictionary<string, string>
             {
-                { m_Setting.GetSettingsLocaleID(), "AchievementManager" },
+                { m_Setting.GetSettingsLocaleID(), "Achievement Manager" },     // space added so name shows nicely in Options list
                 {
                     m_Setting.GetOptionLabelLocaleID(nameof(AchievementManagerSettings.SelectedAchievementKey)),
                     "Selected Dropdown"

--- a/AchievementManager/Mod.cs
+++ b/AchievementManager/Mod.cs
@@ -1,5 +1,6 @@
 ﻿using Colossal.Logging;
 using Colossal.PSI.Common;
+using Colossal.Serialization.Entities;
 
 using Game;
 using Game.Modding;
@@ -24,7 +25,7 @@ namespace AchievementManager
                 LOG.Info($"Current mod asset at {asset.path}");
 
 
-            var myModSetting = new AchievementManagerSettings(this);
+            var myModSetting = new AchievementManagerSettings(Mod.Instance);
             myModSetting.RegisterInOptionsUI();
             GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(myModSetting));
 

--- a/AchievementManager/Mod.cs
+++ b/AchievementManager/Mod.cs
@@ -1,6 +1,6 @@
 ﻿using Colossal.Logging;
 using Colossal.PSI.Common;
-using Colossal.Serialization.Entities;
+
 using Game;
 using Game.Modding;
 using Game.SceneFlow;
@@ -24,11 +24,12 @@ namespace AchievementManager
                 LOG.Info($"Current mod asset at {asset.path}");
 
 
-            var myModSetting = new AchievementManagerSettings(Mod.Instance);
+            var myModSetting = new AchievementManagerSettings(this);
             myModSetting.RegisterInOptionsUI();
             GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(myModSetting));
-            
+
             PlatformManager.instance.achievementsEnabled = true;
+
         }
 
         public void OnDispose()


### PR DESCRIPTION
### Summary ###
**Player.log** Warnings about shipping game DLLs (they  already exist in all player game folders):
```
[WARN] Should NOT be shipped with mod "AchievementManager": Colossal.Localization.dll
[WARN] Should NOT be shipped with mod "AchievementManager": Colossal.PSI.Common.dll
```

### Changes: ###
- **csproj**: use `$(ManagedPath)` and set `<Private>false</Private>` for `Colossal.Localization` and `Colossal.PSI.Common` so they are not copied into the mod. This removes the Player.log warnings.
- AchievementManagerSettings.cs: sort the achievement dropdown alphabetically (case-insensitive) for a more readable list.
- **UI text**: options menu label now “Achievement Manager” (added a space).
- gitignore (minimal): ignore to reduce unneeded noise; .vs/, **/CopilotIndices/, **/*.db*, and build folders **/bin/, **/obj/ 

_No functional behavior changes to mod functions_
